### PR TITLE
:bug: #93 - member statistics 리스트 조회 시 기본 order memberId 로 변경

### DIFF
--- a/src/modules/member-statistics/dtos/find-member-statistics-list-query.dto.ts
+++ b/src/modules/member-statistics/dtos/find-member-statistics-list-query.dto.ts
@@ -5,4 +5,9 @@ import { SortDto } from '@src/dtos/sort.dto';
 export class FindMemberStatisticsListQueryDto extends IntersectionType(
   PageDto,
   SortDto,
-) {}
+) {
+  constructor() {
+    super();
+    this.sortBy = 'memberId';
+  }
+}


### PR DESCRIPTION
## Motivation
- memberstatistics 리스트 조회 시 기본 order by 가 id 로 들어가서 500 에러 나는 에러 수정

<br>

## Key Changes
-

<br>

## To Reviewers
- 