### PR TITLE
Bugfix/115

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,8 @@ import { IsRecordManyConstraint } from './decorators/is-record-many.decorator';
         AWS_S3_BUCKET_NAME: Joi.string(),
         AWS_S3_EXPIRES: Joi.number(),
         AWS_S3_ACL: Joi.string(),
+        GITHUB_CLIENT_ID: Joi.string(),
+        GITHUB_CLIENT_SECRET: Joi.string(),
       }),
       isGlobal: true,
     }),

--- a/src/modules/member/controllers/member.swagger.ts
+++ b/src/modules/member/controllers/member.swagger.ts
@@ -54,10 +54,7 @@ export const ApiLoginOrSignUp = (summary: string) => {
     ),
     ApiFailureResponse(HttpStatus.BAD_REQUEST, ['이미 존재하는 유저입니다.']),
     ApiFailureResponse(HttpStatus.UNAUTHORIZED, ['유효하지 않은 토큰입니다.']),
-    ApiFailureResponse(HttpStatus.FORBIDDEN, [
-      'pending 상태의 유저 입니다.',
-      '비활성된 유저입니다.',
-    ]),
+    ApiFailureResponse(HttpStatus.FORBIDDEN, ['비활성된 유저입니다.']),
     ApiFailureResponse(HttpStatus.NOT_FOUND, ['존재하지 않는 member 입니다.']),
   );
 };

--- a/src/modules/member/services/member-validation.service.spec.ts
+++ b/src/modules/member/services/member-validation.service.spec.ts
@@ -50,25 +50,6 @@ describe('MemberValidationService', () => {
       }).rejects.toThrowError('존재하지 않는 member 입니다.');
     });
 
-    it('pending 상태의 유저인 경우', () => {
-      const account = faker.datatype.string();
-      const loginType = MemberLoginType.Apple;
-      const memberStatus = MemberStatus.Pending;
-      const member = new MemberEntity();
-      member.account = account;
-      member.loginType = loginType;
-      member.status = memberStatus;
-
-      expect(async () => {
-        await memberValidationService.canLoginOrFail(
-          account,
-          loginType,
-          memberStatus,
-          member,
-        );
-      }).rejects.toThrowError('pending 상태의 유저 입니다.');
-    });
-
     it('비활성 유저인 경우', () => {
       const account = faker.datatype.string();
       const loginType = MemberLoginType.Apple;

--- a/src/modules/member/services/member-validation.service.ts
+++ b/src/modules/member/services/member-validation.service.ts
@@ -37,11 +37,6 @@ export class MemberValidationService {
       throw new NotFoundException('존재하지 않는 member 입니다.');
     }
 
-    // pending 상태의 유저인 경우
-    if (memberStatus === MemberStatus.Pending) {
-      throw new ForbiddenException('pending 상태의 유저 입니다.');
-    }
-
     // 비활성 유저인 경우
     if (memberStatus === MemberStatus.Inactive) {
       throw new ForbiddenException('비활성된 유저입니다.');


### PR DESCRIPTION
## Motivation
- pending 상태인 유저에 대해서 201 성공을 내려주게 수정
- 깃헙 accessToken 이 아닌 code 를 받아서 처리

<br>

## Key Changes
-

<br>

## To Reviewers
- 다른 oAuth 들은 token 을 받아서 처리하게끔 되어있는데 깃허브만 code 를 받아서 처리하는 부분이 이상하긴 한데 우선 깃허브만 처리하고 후에 동일하게 맞추는 작업 들어가야 할거같습니다.
- 추가되는 env
  - GITHUB 로 시작하는 환경변수를 깃허브에서 막아놔서 뒤에 붙여 구성했습니다.
  - CLIENT_ID_GITHUB
  - CLIENT_SECRET_GITHUB