### PR TITLE
:sparkles: #141 - 과제 상세조회시 조회수 증가 로직 추가

### DIFF
--- a/src/modules/lesson/controllers/lesson.controller.spec.ts
+++ b/src/modules/lesson/controllers/lesson.controller.spec.ts
@@ -157,9 +157,11 @@ describe('LessonController', () => {
     let param: IdRequestParamDto;
     let member: any;
     let readOneLesson: ReadOneLessonDto;
+    let updatedLesson: LessonEntity;
 
     beforeEach(() => {
       readOneLesson = new ReadOneLessonDto();
+      updatedLesson = new LessonEntity();
       param = {
         id: faker.datatype.number(),
         model: 'lesson',
@@ -169,6 +171,7 @@ describe('LessonController', () => {
       };
 
       lessonService.readOneLesson.mockReturnValue(readOneLesson);
+      lessonService.increaseLessonHit.mockReturnValue(updatedLesson);
     });
 
     it('success - check method called', async () => {
@@ -176,6 +179,8 @@ describe('LessonController', () => {
 
       expect(lessonService.readOneLesson).toBeCalledTimes(1);
       expect(lessonService.readOneLesson).toBeCalledWith(param.id, member.id);
+      expect(lessonService.increaseLessonHit).toBeCalledTimes(1);
+      expect(lessonService.increaseLessonHit).toBeCalledWith(param.id);
     });
 
     it('success - check Input & Output', async () => {

--- a/src/modules/lesson/controllers/lesson.controller.ts
+++ b/src/modules/lesson/controllers/lesson.controller.ts
@@ -112,6 +112,8 @@ export class LessonController {
     );
     const lesson = plainToClass(ReadOneLessonDto, readOneLesson);
 
+    await this.lessonService.increaseLessonHit(param.id);
+
     return { lesson };
   }
 

--- a/src/modules/lesson/services/lesson.service.spec.ts
+++ b/src/modules/lesson/services/lesson.service.spec.ts
@@ -281,4 +281,32 @@ describe('LessonService', () => {
       });
     });
   });
+
+  describe('increaseLessonHit', () => {
+    let lessonId: number;
+    let updatedLesson: LessonEntity;
+
+    beforeEach(() => {
+      lessonId = faker.datatype.number();
+      updatedLesson = new LessonEntity();
+
+      prismaService.lesson.update.mockReturnValue(updatedLesson);
+    });
+
+    it('success - check method called', () => {
+      lessonService.increaseLessonHit(lessonId);
+
+      expect(prismaService.lesson.update).toBeCalledTimes(1);
+      expect(prismaService.lesson.update).toBeCalledWith({
+        where: { id: lessonId },
+        data: { hit: { increment: 1 } },
+      });
+    });
+
+    it('success - check Input & Output', () => {
+      const returnValue = lessonService.increaseLessonHit(lessonId);
+
+      expect(returnValue).toStrictEqual(updatedLesson);
+    });
+  });
 });

--- a/src/modules/lesson/services/lesson.service.ts
+++ b/src/modules/lesson/services/lesson.service.ts
@@ -78,7 +78,7 @@ export class LessonService {
       includeOption.lessonLikes = whereOption;
     }
 
-    return this.prismaService.lesson.findUnique({
+    return this.prismaService.lesson.findFirst({
       where: {
         id: lessonId,
       },
@@ -137,5 +137,12 @@ export class LessonService {
     ]);
 
     return { lessons, totalCount };
+  }
+
+  increaseLessonHit(lessonId: number): Promise<LessonEntity> {
+    return this.prismaService.lesson.update({
+      where: { id: lessonId },
+      data: { hit: { increment: 1 } },
+    });
   }
 }

--- a/test/mock/mock-services.ts
+++ b/test/mock/mock-services.ts
@@ -97,6 +97,7 @@ export const mockLessonService: MockClassType<LessonService> = {
   readOneLesson: jest.fn(),
   deleteLesson: jest.fn(),
   readManyLesson: jest.fn(),
+  increaseLessonHit: jest.fn(),
 };
 
 export const mockLessonHashtagService: MockClassType<LessonHashtagService> = {


### PR DESCRIPTION
## Motivation
- 과제 상세조회시 조회수 증가 로직 추가 api 생성입니다

<br>

## To Reviewers
- 상세 조회시 조회수 증가를 util 함수로 만들까 고민하였으나 각 모듈의 service에서 
  조회수 증가에 대한 메서드를 만들어 사용하는 것이 변경에 유연한 코드라고 생각이 들어 
   increaseLessonHit란 메서드를 만들어 조회수를 단일로 증가시켜 주는 방향으로 설계 하였습니다.
   
-  로그인 하지 않은 유저도 문제 상세 조회가 가능하기 때문에 자기가 만든 문제에 대해서 조회수 증가를 막는 설계는
   허점이 많다고 생각이 들었습니다. 따라서 유저에 상관없이 상세 조회가 되기만 한다면 조회수를 증가시키도록 하였습니다. 
    