### PR TITLE
댓글 500자 제한 될 수 있도록 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -378,7 +378,7 @@ model LessonComment {
   /// 과제 고유 ID
   lessonId    Int
   /// 댓글 설명
-  description String    @db.VarChar(255)
+  description String    @db.Text()
   /// 생성일자  
   createdAt   DateTime  @default(now()) @db.Timestamp(6)
   /// 수정일자
@@ -465,7 +465,7 @@ model LessonSolutionComment {
   /// 문제-풀이 고유 ID
   lessonSolutionId Int
   /// 댓글 설명
-  description      String    @db.VarChar(255)
+  description      String    @db.Text()
   /// 생성일자
   createdAt        DateTime  @default(now()) @db.Timestamp(6)
   /// 수정일자

--- a/src/modules/comment/dtos/create-comment-base.dto.ts
+++ b/src/modules/comment/dtos/create-comment-base.dto.ts
@@ -5,7 +5,6 @@ import { CommentBaseEntity } from '../entities/comment.entity';
 export class CreateCommentBaseDto extends PickType(CommentBaseEntity, [
   'description',
 ]) {
-  // 댓글 길이에 관한 정책이 정해지면 Length 데코레이터가 추가되야 함
   @MaxLength(500)
   @IsString()
   @IsNotEmpty()

--- a/src/modules/comment/dtos/create-comment-base.dto.ts
+++ b/src/modules/comment/dtos/create-comment-base.dto.ts
@@ -1,11 +1,12 @@
 import { PickType } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { CommentBaseEntity } from '../entities/comment.entity';
 
 export class CreateCommentBaseDto extends PickType(CommentBaseEntity, [
   'description',
 ]) {
   // 댓글 길이에 관한 정책이 정해지면 Length 데코레이터가 추가되야 함
+  @MaxLength(500)
   @IsString()
   @IsNotEmpty()
   description: string;

--- a/src/modules/comment/entities/comment.entity.ts
+++ b/src/modules/comment/entities/comment.entity.ts
@@ -12,7 +12,7 @@ export class CommentBaseEntity extends IntersectionType(
   @ApiProperty({
     description: '특정 도메인 게시글에 달린 댓글',
     example: '댓글입니다.',
-    maxLength: 255,
+    maxLength: 500,
   })
   description: string;
 

--- a/src/modules/comment/entities/comment.entity.ts
+++ b/src/modules/comment/entities/comment.entity.ts
@@ -12,6 +12,7 @@ export class CommentBaseEntity extends IntersectionType(
   @ApiProperty({
     description: '특정 도메인 게시글에 달린 댓글',
     example: '댓글입니다.',
+    maxLength: 255,
   })
   description: string;
 


### PR DESCRIPTION
## Motivation
- Comment 테이블의 description 컬럼의 datatype을 varchar(255)에서 text로 변경하였습니다.
   (댓글 작성시 255자는 너무 짧다고 판단하였습니다.)
- CreateCommentBaseDto에서 MaxLength데코레이터를 사용하여 description에 들어올 수 있는 글자수를 500자로 제한하였습니다.
- 
참고로 postgresql에서 text datatype을 사용했을 때 데이터 유형의 최대 길이보다 작은 문자 바이트가 들어오는 경우 
postgresql은 해당 문자 바이트의 저장에 필요한 만큼의 저장 공간만 사용한다고 합니다.
(텍스트 데이터 유형이 저장할 수 있는 전체 고정 저장 공간을 차지하지 않습니다.)